### PR TITLE
fix ipynb

### DIFF
--- a/.copilotignore
+++ b/.copilotignore
@@ -16,7 +16,7 @@ Makefile
 Make
 MIT
 OLD
-*.OLD  
+*.OLD
 *.api
 *.apk
 *.avi
@@ -105,3 +105,4 @@ OLD
 *.yaml
 *.zip
 *.zsh
+*.ipynb

--- a/DISABLE/test.ipynb
+++ b/DISABLE/test.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,7 +181,7 @@ class Extension {
   }
 
   setCopilotStateBasedOnEditors(editors: readonly vscode.TextEditor[]) {
-    const filesOpen = editors.map((editor) => vscode.workspace.asRelativePath(editor.document.uri)).filter((filePath) => !this.isInvalidFile(filePath));
+    const filesOpen = editors.map((editor) => vscode.workspace.asRelativePath(editor.document.uri.fsPath)).filter((filePath) => !this.isInvalidFile(filePath));
     if (filesOpen.length === 0) {
       return;
     }


### PR DESCRIPTION
ipynb files have different uri format (https://github.com/microsoft/vscode/issues/97881#issue-618778392), which may be the reason why the `vscode.workspace.asRelativePath(editor.document.uri)` returns an absolute path instead of a relative path. Changing `vscode.workspace.asRelativePath(editor.document.uri)` to `vscode.workspace.asRelativePath(editor.document.fsPath)` simply fixes this bug.